### PR TITLE
[#4] SDK 사용 인터페이스 타입을 생성해줘요

### DIFF
--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C3391DE82816785900FA9CDC /* HTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DE72816785900FA9CDC /* HTTPClientTests.swift */; };
 		C3391DEB281685D300FA9CDC /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */; };
 		C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEC281695D300FA9CDC /* IGASDK.swift */; };
+		C3391DEF2816965D00FA9CDC /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEE2816965D00FA9CDC /* Location.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -38,6 +39,7 @@
 		C3391DE72816785900FA9CDC /* HTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
 		C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		C3391DEC281695D300FA9CDC /* IGASDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IGASDK.swift; sourceTree = "<group>"; };
+		C3391DEE2816965D00FA9CDC /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -113,6 +115,7 @@
 			children = (
 				C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */,
 				C3391DEC281695D300FA9CDC /* IGASDK.swift */,
+				C3391DEE2816965D00FA9CDC /* Location.swift */,
 				C3391DE52816778E00FA9CDC /* Network */,
 			);
 			path = "DFINERY-SDK";
@@ -243,6 +246,7 @@
 				C3391DDC2816745700FA9CDC /* HTTPClient.swift in Sources */,
 				C3391DE0281675E500FA9CDC /* NetworkRequestRouter.swift in Sources */,
 				C3391DE42816772E00FA9CDC /* EventAdditionResponse.swift in Sources */,
+				C3391DEF2816965D00FA9CDC /* Location.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C3391DEB281685D300FA9CDC /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */; };
 		C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEC281695D300FA9CDC /* IGASDK.swift */; };
 		C3391DEF2816965D00FA9CDC /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEE2816965D00FA9CDC /* Location.swift */; };
+		C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -40,6 +41,7 @@
 		C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		C3391DEC281695D300FA9CDC /* IGASDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IGASDK.swift; sourceTree = "<group>"; };
 		C3391DEE2816965D00FA9CDC /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAdvertisement.swift; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,6 +118,7 @@
 				C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */,
 				C3391DEC281695D300FA9CDC /* IGASDK.swift */,
 				C3391DEE2816965D00FA9CDC /* Location.swift */,
+				C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */,
 				C3391DE52816778E00FA9CDC /* Network */,
 			);
 			path = "DFINERY-SDK";
@@ -244,6 +247,7 @@
 				C3391DDE2816757E00FA9CDC /* HTTPMethod.swift in Sources */,
 				C3391DE22816769400FA9CDC /* NetworkError.swift in Sources */,
 				C3391DDC2816745700FA9CDC /* HTTPClient.swift in Sources */,
+				C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */,
 				C3391DE0281675E500FA9CDC /* NetworkRequestRouter.swift in Sources */,
 				C3391DE42816772E00FA9CDC /* EventAdditionResponse.swift in Sources */,
 				C3391DEF2816965D00FA9CDC /* Location.swift in Sources */,

--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		C3391DE42816772E00FA9CDC /* EventAdditionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DE32816772E00FA9CDC /* EventAdditionResponse.swift */; };
 		C3391DE82816785900FA9CDC /* HTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DE72816785900FA9CDC /* HTTPClientTests.swift */; };
 		C3391DEB281685D300FA9CDC /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */; };
+		C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEC281695D300FA9CDC /* IGASDK.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -36,6 +37,7 @@
 		C3391DE32816772E00FA9CDC /* EventAdditionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAdditionResponse.swift; sourceTree = "<group>"; };
 		C3391DE72816785900FA9CDC /* HTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
 		C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
+		C3391DEC281695D300FA9CDC /* IGASDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IGASDK.swift; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -110,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */,
+				C3391DEC281695D300FA9CDC /* IGASDK.swift */,
 				C3391DE52816778E00FA9CDC /* Network */,
 			);
 			path = "DFINERY-SDK";
@@ -234,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */,
 				C3391DDE2816757E00FA9CDC /* HTTPMethod.swift in Sources */,
 				C3391DE22816769400FA9CDC /* NetworkError.swift in Sources */,
 				C3391DDC2816745700FA9CDC /* HTTPClient.swift in Sources */,

--- a/DFINERY-SDK/DFINERY-SDK/IGASDK.swift
+++ b/DFINERY-SDK/DFINERY-SDK/IGASDK.swift
@@ -15,7 +15,15 @@ final class IGASDK {
 
   private var appKey: String = ""
   private var userProperties: [String: Any]?
+  private var userAdvertisement: UserAdvertisement
+  private var location: Location?
 
+
+  // MARK: Initializers
+
+  init() {
+    self.userAdvertisement = UserAdvertisement()
+  }
 
   public func initIGASDK(appKey: String) {
     self.appKey = appKey
@@ -33,22 +41,21 @@ final class IGASDK {
   // MARK: Set IDFA
 
   public func startGettingIDFA() {
-   
+    self.userAdvertisement.enableGettingIDFA = true
   }
 
   public func stopGettingIDFA() {
-    
+    self.userAdvertisement.enableGettingIDFA = false
   }
 
   public func setAppleAdvertisingIdentifier(_ appleAdvertisingIdentifier: String) {
-    
+    self.userAdvertisement.appleAdvertisingIdentifier = appleAdvertisingIdentifier
   }
 
 
   // MARK: Set Location
 
   public func setLocation(latitude: Double, longitude: Double) {
-    
+    self.location = Location(latitude: latitude, longitude: longitude)
   }
 }
-

--- a/DFINERY-SDK/DFINERY-SDK/IGASDK.swift
+++ b/DFINERY-SDK/DFINERY-SDK/IGASDK.swift
@@ -1,0 +1,54 @@
+//
+//  IGASDK.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import Foundation
+
+final class IGASDK {
+
+  // MARK: Properties
+
+  public static let getInstance = IGASDK()
+
+  private var appKey: String = ""
+  private var userProperties: [String: Any]?
+
+
+  public func initIGASDK(appKey: String) {
+    self.appKey = appKey
+  }
+
+  public func setUserProperties(with keyValues: [String: Any]) {
+    self.userProperties = keyValues
+  }
+
+  public func addEvent(appKey: String, eventName: String, eventProperties: [String: Any]? = nil) {
+    
+  }
+
+
+  // MARK: Set IDFA
+
+  public func startGettingIDFA() {
+   
+  }
+
+  public func stopGettingIDFA() {
+    
+  }
+
+  public func setAppleAdvertisingIdentifier(_ appleAdvertisingIdentifier: String) {
+    
+  }
+
+
+  // MARK: Set Location
+
+  public func setLocation(latitude: Double, longitude: Double) {
+    
+  }
+}
+

--- a/DFINERY-SDK/DFINERY-SDK/Location.swift
+++ b/DFINERY-SDK/DFINERY-SDK/Location.swift
@@ -1,0 +1,13 @@
+//
+//  Location.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import Foundation
+
+struct Location {
+  var latitude: Double
+  var longitude: Double
+}

--- a/DFINERY-SDK/DFINERY-SDK/UserAdvertisement.swift
+++ b/DFINERY-SDK/DFINERY-SDK/UserAdvertisement.swift
@@ -1,0 +1,15 @@
+//
+//  UserAdvertisement.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import Foundation
+
+struct UserAdvertisement {
+  static let defaultIdentifier = "00000000-0000-0000-0000-000000000000"
+
+  var enableGettingIDFA = false
+  var appleAdvertisingIdentifier = UserAdvertisement.defaultIdentifier
+}


### PR DESCRIPTION
## 구현 배경
- #4 

- pseudo 코드 참조
```swift
public class IGASDK
{
    public static void init(string appkey) { ... }                                          // SDK를 초기화 합니다. appkey가 필수적으로 필요합니다.
    public static void setUserProperty(Dictionary<string,object> keyValue) { ... }          // 사용자 속성을 입력합니다.
    public static void addEvent(string eventName, Dictionary<string,object> keyValue) {...} // 이벤트를 입력합니다.
}
```

## 구현 내용
- 이벤트 및 공통 속성으로 사용할 Location, UserAdvertisement 타입들을 사용했어요
