### PR TITLE
[#6] 인코딩을 담당해주는 타입을 생성 및 구현해요

### DIFF
--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		C3391E1628177F4100FA9CDC /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1528177F4100FA9CDC /* UIDevice+Extension.swift */; };
 		C3391E1828177F5600FA9CDC /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1728177F5600FA9CDC /* UIScreen+Extension.swift */; };
 		C3391E1A28177F6D00FA9CDC /* CTCarrier+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1928177F6D00FA9CDC /* CTCarrier+Extension.swift */; };
+		C3391E1C28177FCF00FA9CDC /* FakeDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1B28177FCF00FA9CDC /* FakeDevice.swift */; };
+		C3391E1E28177FDC00FA9CDC /* FakeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1D28177FDC00FA9CDC /* FakeScreen.swift */; };
+		C3391E2028177FEF00FA9CDC /* FakeCarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1F28177FEF00FA9CDC /* FakeCarrier.swift */; };
+		C3391E222817800600FA9CDC /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E212817800600FA9CDC /* RequestBuilderTests.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -50,6 +54,10 @@
 		C3391E1528177F4100FA9CDC /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
 		C3391E1728177F5600FA9CDC /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
 		C3391E1928177F6D00FA9CDC /* CTCarrier+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CTCarrier+Extension.swift"; sourceTree = "<group>"; };
+		C3391E1B28177FCF00FA9CDC /* FakeDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeDevice.swift; sourceTree = "<group>"; };
+		C3391E1D28177FDC00FA9CDC /* FakeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeScreen.swift; sourceTree = "<group>"; };
+		C3391E1F28177FEF00FA9CDC /* FakeCarrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCarrier.swift; sourceTree = "<group>"; };
+		C3391E212817800600FA9CDC /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,6 +106,9 @@
 			isa = PBXGroup;
 			children = (
 				C3391DEA281685D300FA9CDC /* MockURLProtocol.swift */,
+				C3391E1B28177FCF00FA9CDC /* FakeDevice.swift */,
+				C3391E1D28177FDC00FA9CDC /* FakeScreen.swift */,
+				C3391E1F28177FEF00FA9CDC /* FakeCarrier.swift */,
 			);
 			path = "Test Doubles";
 			sourceTree = "<group>";
@@ -149,6 +160,7 @@
 			children = (
 				C3391DE9281685C200FA9CDC /* Test Doubles */,
 				C3391DE72816785900FA9CDC /* HTTPClientTests.swift */,
+				C3391E212817800600FA9CDC /* RequestBuilderTests.swift */,
 			);
 			path = "DFINERY-SDKTests";
 			sourceTree = "<group>";
@@ -284,6 +296,10 @@
 			files = (
 				C3391DE82816785900FA9CDC /* HTTPClientTests.swift in Sources */,
 				C3391DEB281685D300FA9CDC /* MockURLProtocol.swift in Sources */,
+				C3391E1E28177FDC00FA9CDC /* FakeScreen.swift in Sources */,
+				C3391E222817800600FA9CDC /* RequestBuilderTests.swift in Sources */,
+				C3391E2028177FEF00FA9CDC /* FakeCarrier.swift in Sources */,
+				C3391E1C28177FCF00FA9CDC /* FakeDevice.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		C3391DEF2816965D00FA9CDC /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEE2816965D00FA9CDC /* Location.swift */; };
 		C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */; };
 		C3391E1328177E0600FA9CDC /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1228177E0600FA9CDC /* RequestBuilder.swift */; };
+		C3391E1628177F4100FA9CDC /* UIDevice+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1528177F4100FA9CDC /* UIDevice+Extension.swift */; };
+		C3391E1828177F5600FA9CDC /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1728177F5600FA9CDC /* UIScreen+Extension.swift */; };
+		C3391E1A28177F6D00FA9CDC /* CTCarrier+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1928177F6D00FA9CDC /* CTCarrier+Extension.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -44,6 +47,9 @@
 		C3391DEE2816965D00FA9CDC /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAdvertisement.swift; sourceTree = "<group>"; };
 		C3391E1228177E0600FA9CDC /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
+		C3391E1528177F4100FA9CDC /* UIDevice+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extension.swift"; sourceTree = "<group>"; };
+		C3391E1728177F5600FA9CDC /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
+		C3391E1928177F6D00FA9CDC /* CTCarrier+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CTCarrier+Extension.swift"; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,6 +102,16 @@
 			path = "Test Doubles";
 			sourceTree = "<group>";
 		};
+		C3391E1428177F2C00FA9CDC /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				C3391E1528177F4100FA9CDC /* UIDevice+Extension.swift */,
+				C3391E1728177F5600FA9CDC /* UIScreen+Extension.swift */,
+				C3391E1928177F6D00FA9CDC /* CTCarrier+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		C37CE72F2810E2EE0025B233 = {
 			isa = PBXGroup;
 			children = (
@@ -123,6 +139,7 @@
 				C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */,
 				C3391E1228177E0600FA9CDC /* RequestBuilder.swift */,
 				C3391DE52816778E00FA9CDC /* Network */,
+				C3391E1428177F2C00FA9CDC /* Extension */,
 			);
 			path = "DFINERY-SDK";
 			sourceTree = "<group>";
@@ -249,12 +266,15 @@
 				C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */,
 				C3391DDE2816757E00FA9CDC /* HTTPMethod.swift in Sources */,
 				C3391DE22816769400FA9CDC /* NetworkError.swift in Sources */,
+				C3391E1828177F5600FA9CDC /* UIScreen+Extension.swift in Sources */,
+				C3391E1628177F4100FA9CDC /* UIDevice+Extension.swift in Sources */,
 				C3391E1328177E0600FA9CDC /* RequestBuilder.swift in Sources */,
 				C3391DDC2816745700FA9CDC /* HTTPClient.swift in Sources */,
 				C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */,
 				C3391DE0281675E500FA9CDC /* NetworkRequestRouter.swift in Sources */,
 				C3391DE42816772E00FA9CDC /* EventAdditionResponse.swift in Sources */,
 				C3391DEF2816965D00FA9CDC /* Location.swift in Sources */,
+				C3391E1A28177F6D00FA9CDC /* CTCarrier+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
+++ b/DFINERY-SDK/DFINERY-SDK.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEC281695D300FA9CDC /* IGASDK.swift */; };
 		C3391DEF2816965D00FA9CDC /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DEE2816965D00FA9CDC /* Location.swift */; };
 		C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */; };
+		C3391E1328177E0600FA9CDC /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3391E1228177E0600FA9CDC /* RequestBuilder.swift */; };
 		C37CE7422810E2EE0025B233 /* DFINERY_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */; };
 		C37CE7482810E2EE0025B233 /* DFINERY_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -42,6 +43,7 @@
 		C3391DEC281695D300FA9CDC /* IGASDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IGASDK.swift; sourceTree = "<group>"; };
 		C3391DEE2816965D00FA9CDC /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAdvertisement.swift; sourceTree = "<group>"; };
+		C3391E1228177E0600FA9CDC /* RequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		C37CE7392810E2EE0025B233 /* DFINERY_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DFINERY_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C37CE73C2810E2EE0025B233 /* DFINERY_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DFINERY_SDK.h; sourceTree = "<group>"; };
 		C37CE7412810E2EE0025B233 /* DFINERY-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DFINERY-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +121,7 @@
 				C3391DEC281695D300FA9CDC /* IGASDK.swift */,
 				C3391DEE2816965D00FA9CDC /* Location.swift */,
 				C3391DF0281696B200FA9CDC /* UserAdvertisement.swift */,
+				C3391E1228177E0600FA9CDC /* RequestBuilder.swift */,
 				C3391DE52816778E00FA9CDC /* Network */,
 			);
 			path = "DFINERY-SDK";
@@ -246,6 +249,7 @@
 				C3391DED281695D300FA9CDC /* IGASDK.swift in Sources */,
 				C3391DDE2816757E00FA9CDC /* HTTPMethod.swift in Sources */,
 				C3391DE22816769400FA9CDC /* NetworkError.swift in Sources */,
+				C3391E1328177E0600FA9CDC /* RequestBuilder.swift in Sources */,
 				C3391DDC2816745700FA9CDC /* HTTPClient.swift in Sources */,
 				C3391DF1281696B200FA9CDC /* UserAdvertisement.swift in Sources */,
 				C3391DE0281675E500FA9CDC /* NetworkRequestRouter.swift in Sources */,

--- a/DFINERY-SDK/DFINERY-SDK/Extension/CTCarrier+Extension.swift
+++ b/DFINERY-SDK/DFINERY-SDK/Extension/CTCarrier+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  CTCarrier+Extension.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/26.
+//
+
+import CoreTelephony
+
+public protocol CTCarrierLogic {
+  var carrierName: String? { get }
+}
+
+extension CTCarrier: CTCarrierLogic { }

--- a/DFINERY-SDK/DFINERY-SDK/Extension/UIDevice+Extension.swift
+++ b/DFINERY-SDK/DFINERY-SDK/Extension/UIDevice+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  UIDevice+Extension.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import UIKit
+
+public protocol UIDeviceLogic {
+  var systemVersion: String { get }
+  var name: String { get }
+  var orientation: UIDeviceOrientation { get }
+}
+
+extension UIDevice: UIDeviceLogic { }

--- a/DFINERY-SDK/DFINERY-SDK/Extension/UIScreen+Extension.swift
+++ b/DFINERY-SDK/DFINERY-SDK/Extension/UIScreen+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UIScreen.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import UIKit
+
+public protocol UIScreenLogic {
+  var nativeBounds: CGRect { get }
+}
+
+extension UIScreen: UIScreenLogic { }

--- a/DFINERY-SDK/DFINERY-SDK/Location.swift
+++ b/DFINERY-SDK/DFINERY-SDK/Location.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Location {
+public struct Location {
   var latitude: Double
   var longitude: Double
 }

--- a/DFINERY-SDK/DFINERY-SDK/RequestBuilder.swift
+++ b/DFINERY-SDK/DFINERY-SDK/RequestBuilder.swift
@@ -18,18 +18,18 @@ public final class RequestBuilder: RequestBuilderLogic {
   // MARK: Properties
 
   private let monitor: NWPathMonitor
-  private let device: UIDevice
-  private let screen: UIScreen
-  private let carriers: [String: CTCarrier]?
+  private let device: UIDeviceLogic
+  private let screen: UIScreenLogic
+  private let carriers: [String: CTCarrierLogic]?
   private let languages: [String]
 
 
   // MARK: Initializers
 
   public init(monitor: NWPathMonitor = NWPathMonitor(),
-       device: UIDevice = UIDevice.current,
-       screen: UIScreen = UIScreen.main,
-       carriers: [String: CTCarrier]? = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders,
+       device: UIDeviceLogic = UIDevice.current,
+       screen: UIScreenLogic = UIScreen.main,
+       carriers: [String: CTCarrierLogic]? = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders,
        languages: [String] = NSLocale.preferredLanguages) {
     self.monitor = monitor
     self.device = device
@@ -46,7 +46,7 @@ public final class RequestBuilder: RequestBuilderLogic {
 
   // MARK: HTTP Request Body (Data?)
 
-  func httpRequestBody(with appKey: String, eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, userAdvertisement: UserAdvertisement, location: Location?) -> Data? {
+  public func httpRequestBody(with appKey: String, eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, userAdvertisement: UserAdvertisement, location: Location?) -> Data? {
     let keyValues: [String: Any] = self.keyValues(
       with: appKey,
       eventName: eventName,

--- a/DFINERY-SDK/DFINERY-SDK/RequestBuilder.swift
+++ b/DFINERY-SDK/DFINERY-SDK/RequestBuilder.swift
@@ -1,0 +1,209 @@
+//
+//  RequestBuilder.swift
+//  DFINERY-SDK
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import CoreTelephony
+import Network
+import UIKit
+
+protocol RequestBuilderLogic {
+  func httpRequestBody(with appKey: String, eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, userAdvertisement: UserAdvertisement, location: Location?) -> Data?
+}
+
+public final class RequestBuilder: RequestBuilderLogic {
+
+  // MARK: Properties
+
+  private let monitor: NWPathMonitor
+  private let device: UIDevice
+  private let screen: UIScreen
+  private let carriers: [String: CTCarrier]?
+  private let languages: [String]
+
+
+  // MARK: Initializers
+
+  public init(monitor: NWPathMonitor = NWPathMonitor(),
+       device: UIDevice = UIDevice.current,
+       screen: UIScreen = UIScreen.main,
+       carriers: [String: CTCarrier]? = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders,
+       languages: [String] = NSLocale.preferredLanguages) {
+    self.monitor = monitor
+    self.device = device
+    self.screen = screen
+    self.carriers = carriers
+    self.languages = languages
+    self.monitor.start(queue: DispatchQueue.global())
+  }
+
+  deinit {
+    self.monitor.cancel()
+  }
+
+
+  // MARK: HTTP Request Body (Data?)
+
+  func httpRequestBody(with appKey: String, eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, userAdvertisement: UserAdvertisement, location: Location?) -> Data? {
+    let keyValues: [String: Any] = self.keyValues(
+      with: appKey,
+      eventName: eventName,
+      eventProperties: eventProperties,
+      userProperties: userProperties,
+      userAdvertisement: userAdvertisement,
+      location: location
+    )
+    let data = self.encode(keyValues)
+    return data
+  }
+
+  private func keyValues(with appKey: String, eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, userAdvertisement: UserAdvertisement, location: Location?) -> [String: Any] {
+    return [
+      "evt": self.eventKeyValues(
+        with: eventName,
+        eventProperties: eventProperties,
+        userProperties: userProperties,
+        location: location
+      ),
+      "common": self.commonInfoKeyValues(
+        with: appKey,
+        userAdvertisement: userAdvertisement
+      )
+    ]
+  }
+
+  private func encode(_ keyValues: [String: Any]) -> Data? {
+    guard let jsonData = try? JSONSerialization.data(
+      withJSONObject: keyValues,
+      options: .prettyPrinted
+    ) else {
+      return nil
+    }
+    return jsonData
+  }
+
+  private func eventKeyValues(with eventName: String, eventProperties: [String: Any]?, userProperties: [String: Any]?, location: Location?) -> [String: Any] {
+    var keyValues: [String: Any] = [
+      "created_at": self.createdDateText(),
+      "event": eventName
+    ]
+    if let location = self.locationKeyValues(with: location) {
+      keyValues["location"] = location
+    }
+    if let eventParameters = eventProperties {
+      keyValues["param"] = eventParameters
+    }
+    if let userProperties = userProperties {
+      keyValues["user_properties"] = userProperties
+    }
+    return keyValues
+  }
+
+  private func createdDateText() -> String {
+    let date = Date()
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyyMMddHHmmss"
+    let dateText = dateFormatter.string(from: date)
+    return dateText
+  }
+
+  private func locationKeyValues(with location: Location?) -> [String: Double]? {
+    guard let location = location else { return nil }
+    return ["lat": location.latitude, "lng": location.longitude]
+  }
+
+  private func commonInfoKeyValues(with appKey: String, userAdvertisement: UserAdvertisement) -> [String: Any] {
+    var keyValues: [String: Any] = [
+      "identity": self.identityKeyValues(with: userAdvertisement),
+      "device_info": self.deviceKeyValues(),
+      "appkey": self.appKey(with: appKey)
+    ]
+    if let packageName = self.packageName() {
+      keyValues["package_name"] = packageName
+    }
+    return keyValues
+  }
+
+  private func identityKeyValues(with userAdvertisement: UserAdvertisement) -> [String: Any] {
+    let enabled = userAdvertisement.enableGettingIDFA
+    let advertisingIdentifier = enabled == true ? userAdvertisement.appleAdvertisingIdentifier : UserAdvertisement.defaultIdentifier
+    return ["adid": advertisingIdentifier, "adid_opt_out": enabled]
+  }
+
+  private func deviceKeyValues() -> [String: Any] {
+    var keyValues: [String: Any] = [
+      "os": self.osVersion(),
+      "model": self.deviceModel(),
+      "resolution": self.resolution(),
+      "is_portrait": self.isPortrait(),
+      "platform": self.platForm(),
+      "network": self.networkStatus()
+    ]
+    if let carrierName = self.carrierName() {
+      keyValues["carrier"] = carrierName
+    }
+    if let pair = self.languageRegionPair() {
+      keyValues["language"] = pair.language
+      keyValues["country"] = pair.region
+    }
+    return keyValues
+  }
+
+  private func osVersion() -> String {
+    return self.device.systemVersion
+  }
+
+  private func deviceModel() -> String {
+    return self.device.name
+  }
+
+  private func resolution() -> String {
+    let nativeBounds = self.screen.nativeBounds
+    let width = Int(nativeBounds.width)
+    let height = Int(nativeBounds.height)
+    return "\(width)x\(height)"
+  }
+
+  private func isPortrait() -> Bool {
+    return self.device.orientation == .portrait
+  }
+
+  private func platForm() -> String {
+    return "iOS"
+  }
+
+  private func networkStatus() -> String {
+    if self.monitor.currentPath.usesInterfaceType(.wifi) {
+      return "wifi"
+    } else if self.monitor.currentPath.usesInterfaceType(.cellular) {
+      return "cellular"
+    } else {
+      return "disconnect"
+    }
+  }
+
+  private func carrierName() -> String? {
+    guard let carriers = self.carriers?.values else { return nil }
+    let carrierName = carriers
+      .filter { $0.carrierName != nil }
+      .map { $0.carrierName! }
+      .joined(separator: "+")
+    return carrierName
+  }
+
+  private func languageRegionPair() -> (language: String, region: String)? {
+    guard let section = self.languages.first?.split(separator: "-") else { return nil }
+    return (String(section[0]), String(section[1]))
+  }
+
+  private func packageName() -> String? {
+    guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return nil }
+    return "\(bundleIdentifier)"
+  }
+
+  private func appKey(with key: String) -> String {
+    return "appKey \(key)"
+  }
+}

--- a/DFINERY-SDK/DFINERY-SDK/UserAdvertisement.swift
+++ b/DFINERY-SDK/DFINERY-SDK/UserAdvertisement.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserAdvertisement {
+public struct UserAdvertisement {
   static let defaultIdentifier = "00000000-0000-0000-0000-000000000000"
 
   var enableGettingIDFA = false

--- a/DFINERY-SDK/DFINERY-SDKTests/RequestBuilderTests.swift
+++ b/DFINERY-SDK/DFINERY-SDKTests/RequestBuilderTests.swift
@@ -1,0 +1,76 @@
+//
+//  RequestBuilderTests.swift
+//  DFINERY-SDKTests
+//
+//  Created by 이영우 on 2022/04/25.
+//
+
+import CoreTelephony
+import Network
+import XCTest
+@testable import DFINERY_SDK
+
+final class RequestBuilderTests: XCTestCase {
+  private var sut: RequestBuilder!
+
+  func test_when_addEvent에_대한_HttpRequestBody_then_정상적으로_인코딩_확인() {
+    // given
+    let monitor = NWPathMonitor(requiredInterfaceType: .cellular)
+    let device = FakeDevice(
+      systemVersion: "15.3",
+      name: "iPhone 13 mini",
+      orientation: .portrait
+    )
+    let screen = FakeScreen(
+      width: 750.0,
+      height: 1334.0
+    )
+    let carrier = FakeCarrier(
+      carrierName: "KT"
+    )
+    let carriers: [String: CTCarrierLogic] = [
+      "dummyKey": carrier
+    ]
+    let languages = ["ko-kr"]
+    self.sut = RequestBuilder(
+      monitor: monitor,
+      device: device,
+      screen: screen,
+      carriers: carriers,
+      languages: languages
+    )
+    let userAdvertisement = UserAdvertisement(
+      enableGettingIDFA: true,
+      appleAdvertisingIdentifier: "12531864-3040-0237-1290-541026403320"
+    )
+    let location = Location(
+      latitude: 23.0,
+      longitude: 322.1
+    )
+
+    let expectedPackageName = """
+       "package_name" : "com.apple.dt.xctest.tool",
+    """
+    let expectedEvent = """
+      "event" : "Touch Login Button"
+    """
+    let expectedAppKey = """
+      "appkey" : "appKey lyw2100@naver.com"
+    """
+
+    // when
+    let data = self.sut.httpRequestBody(
+      with: "lyw2100@naver.com",
+      eventName: "Touch Login Button",
+      eventProperties: ["menu_name": "login"],
+      userProperties: ["gender": "male"],
+      userAdvertisement: userAdvertisement,
+      location: location
+    )
+    let textToCompare = String(data: data!, encoding: .utf8)!
+
+    XCTAssertTrue(textToCompare.contains(expectedPackageName))
+    XCTAssertTrue(textToCompare.contains(expectedEvent))
+    XCTAssertTrue(textToCompare.contains(expectedAppKey))
+  }
+}

--- a/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeCarrier.swift
+++ b/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeCarrier.swift
@@ -1,0 +1,17 @@
+//
+//  FakeCarrier.swift
+//  DFINERY-SDKTests
+//
+//  Created by 이영우 on 2022/04/26.
+//
+
+import Foundation
+import DFINERY_SDK
+
+final class FakeCarrier: CTCarrierLogic {
+  var carrierName: String?
+
+  init(carrierName: String?) {
+    self.carrierName = carrierName
+  }
+}

--- a/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeDevice.swift
+++ b/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeDevice.swift
@@ -1,0 +1,21 @@
+//
+//  FakeDevice.swift
+//  DFINERY-SDKTests
+//
+//  Created by 이영우 on 2022/04/26.
+//
+
+import UIKit
+import DFINERY_SDK
+
+final class FakeDevice: UIDeviceLogic {
+  var systemVersion: String = "4.4.4"
+  var name: String = "iPhone8"
+  var orientation: UIDeviceOrientation = .portrait
+
+  init(systemVersion: String, name: String, orientation: UIDeviceOrientation) {
+    self.systemVersion = systemVersion
+    self.name = name
+    self.orientation = orientation
+  }
+}

--- a/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeScreen.swift
+++ b/DFINERY-SDK/DFINERY-SDKTests/Test Doubles/FakeScreen.swift
@@ -1,0 +1,17 @@
+//
+//  FakeScreen.swift
+//  DFINERY-SDKTests
+//
+//  Created by 이영우 on 2022/04/26.
+//
+
+import UIKit
+import DFINERY_SDK
+
+final class FakeScreen: UIScreenLogic {
+  var nativeBounds: CGRect
+
+  init(width: Double, height: Double) {
+    self.nativeBounds = CGRect(x: 0, y: 0, width: width, height: height)
+  }
+}


### PR DESCRIPTION
## 작업 배경
- #6 

## 변경 사항
- Dictionary로 인코딩할 데이터를 가져오므로 정확한 KeyValue를 알 수 없어 JSONSerialization 을 통해서 Encoding 을 해야 해서 따로 Dictionary를 만들어줄 타입을 만들었어요 ( RequestBuilder )
- 테스트를 하기 위해서는 UIDevice, UIScreen 등의 의존성을 주입해줘야 해서 프로토콜을 생성하고 기존의 객체들에 채택해줌으로써 Fake 객체를 주입할 수 있도록 구조를 잡았어요

## 테스트
- Fake 객체를 통해서 상황을 가정하고, 그에 맞는 HttpRequestBody 가 형성되었는지 직접 확인하였어요.
- Encoding 을 수행할 경우 Dictionary는 순서를 보장하지 않기 때문에 contain을 통해서 확인을 했어요